### PR TITLE
Fix from k6 troubleshooting docs

### DIFF
--- a/DotNetCore/Dockerfile
+++ b/DotNetCore/Dockerfile
@@ -29,6 +29,7 @@ RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 RUN curl -sSL https://get.docker.com/ | sh
 
 # Install k6 for load testing
+RUN gpg -k
 RUN gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
 RUN echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | tee /etc/apt/sources.list.d/k6.list
 RUN apt-get update


### PR DESCRIPTION
https://k6.io/docs/get-started/installation/troubleshooting/#error-importing-k6s-gpg-key