### PR TITLE
Revert "Update Advanced Installer version to 23.9"

### DIFF
--- a/DotNetFrameworkAlt/dockerfile
+++ b/DotNetFrameworkAlt/dockerfile
@@ -28,8 +28,8 @@ RUN choco install --parallel \
     7zip.install \
     msbuild.communitytasks
 
-RUN choco install advanced-installer --version 23.9; \
-    setx AdvancedInstaller 'C:\Program Files (x86)\Caphyon\Advanced Installer 23.9\bin\x86\AdvancedInstaller.com' /M
+RUN choco install advanced-installer --version 22.0; \
+    setx AdvancedInstaller 'C:\Program Files (x86)\Caphyon\Advanced Installer 22.0\bin\x86\AdvancedInstaller.com' /M
 
 RUN choco install dotnetreactor --version 6.9.0.0 --ignore-checksums
 


### PR DESCRIPTION
Reverts RedevLtd/AzurePipelineAgentsDocker#43

because we worked out how to make .net 10 a pre req of SalonTracker .aip without updating Advanced Installer